### PR TITLE
Add method dropPrimary & dropForeign

### DIFF
--- a/App/Core/Blueprint.php
+++ b/App/Core/Blueprint.php
@@ -524,6 +524,19 @@ class Blueprint
         $sql = 'ALTER TABLE ' . $this->table . ' DROP COLUMN ' . $column . ';';
         $this->connection->exec($sql);
     }
+
+    public function dropPrimary()
+    {
+        $sql = 'ALTER TABLE ' . $this->table . ' DROP PRIMARY KEY;';
+        $this->connection->exec($sql);
+    }
+
+    public function dropForeign()
+    {
+        $sql = 'ALTER TABLE ' . $this->table . ' DROP FOREIGN KEY ' . $this->foreign . ';';
+        $this->connection->exec($sql);
+    }
+
     public function addColumn(string $column)
     {
         $sql = 'ALTER TABLE ' . $this->table . ' ADD COLUMN ' . $column . ';';


### PR DESCRIPTION
**Pull Request Description**

**Overview:**
This pull request introduces two new methods, `dropPrimary()` and `dropForeign()`, to the class. These methods enable the manipulation of database tables by executing SQL queries to drop primary keys and foreign keys, respectively. 

**Changes Made:**
- Added a new method called `dropPrimary()` to the class. This method constructs an SQL query to remove the primary key constraint from a specified database table.
- Added another new method called `dropForeign()` to the class. This method constructs an SQL query to drop a specific foreign key constraint from the same database table.
- Both methods utilize the provided `$this->table` and `$this->foreign` properties to dynamically generate SQL statements.
- The `exec()` method from the class's `$connection` property is used to execute the SQL queries.

**Example Usage:**
To remove the primary key constraint on a table named `$this->table` using the `dropPrimary()` method, you can call it like this:
```php
$instance->dropPrimary();
