### PR TITLE
refactor: Add method whereNotIn to core Model

### DIFF
--- a/App/Core/Model.php
+++ b/App/Core/Model.php
@@ -73,6 +73,21 @@ class Model
         return $statement->fetchAll(PDO::FETCH_OBJ);
     }
 
+    public function whereNotIn(string $column, array $data): array
+    {
+        $query = "SELECT * FROM {$this->table} WHERE {$column} NOT IN (";
+        $query .= implode(', ', array_map(function ($key) {
+            return ':' . $key;
+        }, array_keys($data)));
+        $query .= ")";
+        $statement = $this->statement->prepare($query);
+        foreach ($data as $key => $value) {
+            $statement->bindValue(':' . $key, $value);
+        }
+        $statement->execute();
+        return $statement->fetchAll(PDO::FETCH_OBJ);
+    }
+
     public function create(array $data): bool
     {
         $query = "INSERT INTO {$this->table} SET ";
@@ -118,6 +133,7 @@ class Model
         return $statement->execute();
     }
 
+
     public function delete(int $id): bool
     {
         $query = "DELETE FROM {$this->table} WHERE {$this->primaryKey} = :id";
@@ -125,6 +141,4 @@ class Model
         $statement->bindValue(':id', $id);
         return $statement->execute();
     }
-
-
 }


### PR DESCRIPTION
## Refactor: Add method `whereNotIn` to core Model

### Description
This pull request introduces a new method, `whereNotIn`, to the core Model class. The `whereNotIn` method allows users to build and execute SQL queries to retrieve records from the database where a specified column's value is not in a given array of values.

### Changes Made
- Added a new public method, `whereNotIn`, to the core Model class.
- The method accepts two parameters: `$column` (string) and `$data` (array).
- It constructs and executes a SQL query that retrieves records from the database table where the specified column's value is not in the provided array of values.
- The results are returned as an array of objects, using PDO's `FETCH_OBJ` fetch style.

### Usage Example
```php
$model = new Model();
$column = 'status';
$data = ['draft', 'pending'];

$results = $model->whereNotIn($column, $data);
