### PR TITLE
refactor(core): add method WhereIn for core model

### DIFF
--- a/App/Core/Model.php
+++ b/App/Core/Model.php
@@ -73,6 +73,21 @@ class Model
         return $statement->fetchAll(PDO::FETCH_OBJ);
     }
 
+    public function whereIn(string $column, array $data): array
+    {
+        $query = "SELECT * FROM {$this->table} WHERE {$column} IN (";
+        $query .= implode(', ', array_map(function ($key) {
+            return ':' . $key;
+        }, array_keys($data)));
+        $query .= ")";
+        $statement = $this->statement->prepare($query);
+        foreach ($data as $key => $value) {
+            $statement->bindValue(':' . $key, $value);
+        }
+        $statement->execute();
+        return $statement->fetchAll(PDO::FETCH_OBJ);
+    }
+
     public function whereNotIn(string $column, array $data): array
     {
         $query = "SELECT * FROM {$this->table} WHERE {$column} NOT IN (";


### PR DESCRIPTION
## Pull Request: Refactor Core Model - Add `WhereIn` Method

### Description

This pull request aims to enhance the core model by introducing a new method called `whereIn`. The `whereIn` method allows for simplified SQL queries involving the `IN` clause, making it easier to fetch records based on a list of values for a specific column.

### Changes Made

- Added a new method `whereIn` to the core model.
- The `whereIn` method generates a SQL query with parameterized placeholders for the values to be included in the `IN` clause.
- The method binds values to the placeholders and executes the query, returning the results as an array of objects.

### Code Snippet

```php
public function whereIn(string $column, array $data): array
{
    $query = "SELECT * FROM {$this->table} WHERE {$column} IN (";
    $query .= implode(', ', array_map(function ($key) {
        return ':' . $key;
    }, array_keys($data)));
    $query .= ")";
    $statement = $this->statement->prepare($query);
    foreach ($data as $key => $value) {
        $statement->bindValue(':' . $key, $value);
    }
    $statement->execute();
    return $statement->fetchAll(PDO::FETCH_OBJ);
}
