### PR TITLE
refactor(core): :recycle: add method insertGetId for get id after insert data to table

### DIFF
--- a/App/Core/QueryBuilder.php
+++ b/App/Core/QueryBuilder.php
@@ -228,6 +228,20 @@ class QueryBuilder
         }
     }
 
+    public function insertGetId(array $data): int
+    {
+        $columns = implode(', ', array_keys($data));
+        $values = implode(', ', array_map(function ($column) {
+            return ':' . $column;
+        }, array_keys($data)));
+        $query = "INSERT INTO {$this->table} ({$columns}) VALUES ({$values})";
+        $statement = $this->connection->prepare($query);
+        foreach ($data as $key => $value) {
+            $statement->bindValue(':' . $key, $value);
+        }
+        $statement->execute();
+        return (int)$this->connection->lastInsertId();
+    }
 
     public function get(): array
     {


### PR DESCRIPTION
## Pull Request: Refactor Core Model - Add `insertGetId` Method

### Description

This pull request introduces a new method called `insertGetId` to the core model. The `insertGetId` method simplifies the process of inserting data into a table and retrieving the auto-generated ID of the inserted record. This is particularly useful for scenarios where you need to perform an insert operation and immediately get the ID of the newly inserted row.

### Changes Made

- Added a new method `insertGetId` to the core model.
- The `insertGetId` method accepts an associative array of data to be inserted into the table.
- It constructs a parameterized SQL query for the insert operation.
- The method binds values to the placeholders and executes the query.
- Finally, it returns the auto-generated ID of the inserted record as an integer.
